### PR TITLE
Test-9

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -41732,9 +41732,10 @@ THH:mm:ss.sss
             1. Set _taRecord_ to MakeTypedArrayWithBufferWitnessRecord(_O_, ~seq-cst~).
             1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
             1. Set _len_ to TypedArrayLength(_taRecord_).
+            1. NOTE: Side-effects of the above steps may have reduced the size of _O_, in which case copying should proceed with the longest still-applicable prefix.
+            1. Set _count_ to min(_count_, _len_ - _startIndex_, _len_ - _targetIndex_).
             1. Let _elementSize_ be TypedArrayElementSize(_O_).
             1. Let _byteOffset_ be _O_.[[ByteOffset]].
-            1. Let _bufferByteLimit_ be (_len_ × _elementSize_) + _byteOffset_.
             1. Let _toByteIndex_ be (_targetIndex_ × _elementSize_) + _byteOffset_.
             1. Let _fromByteIndex_ be (_startIndex_ × _elementSize_) + _byteOffset_.
             1. Let _countBytes_ be _count_ × _elementSize_.
@@ -41745,14 +41746,11 @@ THH:mm:ss.sss
             1. Else,
               1. Let _direction_ be 1.
             1. Repeat, while _countBytes_ > 0,
-              1. If _fromByteIndex_ &lt; _bufferByteLimit_ and _toByteIndex_ &lt; _bufferByteLimit_, then
-                1. Let _value_ be GetValueFromBuffer(_buffer_, _fromByteIndex_, ~uint8~, *true*, ~unordered~).
-                1. Perform SetValueInBuffer(_buffer_, _toByteIndex_, ~uint8~, _value_, *true*, ~unordered~).
-                1. Set _fromByteIndex_ to _fromByteIndex_ + _direction_.
-                1. Set _toByteIndex_ to _toByteIndex_ + _direction_.
-                1. Set _countBytes_ to _countBytes_ - 1.
-              1. Else,
-                1. Set _countBytes_ to 0.
+              1. Let _value_ be GetValueFromBuffer(_buffer_, _fromByteIndex_, ~uint8~, *true*, ~unordered~).
+              1. Perform SetValueInBuffer(_buffer_, _toByteIndex_, ~uint8~, _value_, *true*, ~unordered~).
+              1. Set _fromByteIndex_ to _fromByteIndex_ + _direction_.
+              1. Set _toByteIndex_ to _toByteIndex_ + _direction_.
+              1. Set _countBytes_ to _countBytes_ - 1.
           1. Return _O_.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
…ver elements still fit (#3619)

...regardless of copy direction

Fixes #3618

This aligns the spec with implementation reality.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
